### PR TITLE
[FIX] gse_picking_status: Do Not Consider Services in Reception Status

### DIFF
--- a/models/purchase.py
+++ b/models/purchase.py
@@ -19,7 +19,7 @@ class PurchaseOrder(models.Model):
             if not order.picking_ids or all(p.state == 'cancel' for p in order.picking_ids):
                 order.receipt_status = False
             elif all(p.state in ['done', 'cancel'] for p in order.picking_ids):
-                if all(float_compare(line.qty_received, line.product_qty, precision_digits=5) >= 0 for line in order.order_line):
+                if all(line.product_id.type == 'service' or float_compare(line.qty_received, line.product_qty, precision_digits=5) >= 0 for line in order.order_line):
                     order.receipt_status = 'full'
                 else:
                     order.receipt_status = 'partial'


### PR DESCRIPTION
**Rationale**
When a service is on a PO (also SO but the issue is not related), it's never marked as received. 
Thus, the PO stay in the state "Partially Received", eg. PO/08147, with the price difference that wasn't received.

In standard, to mark the PO as fully received:

Unlock the PO
Edit the column "Received" for the Service Products.
Save
The current process is somewhat inconvenient, and it could be further improved by not tracking services in the reception status.

**Specification**
Do not consider Product type "services" in the PO Reception status